### PR TITLE
Update base image, and empty the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,1 @@
-FROM quay.io/actcat/devon_rex_base:1.0.1
-
-# Ruby is installed in buildpack_base
-
-# skip installing gem documentation
-RUN echo 'gem: --no3rdoc --no-ri' >> "$HOME/.gemrc"
-
-# install things globally, for great justice
-ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN gem install bundler \
-  && bundle config --global path "$GEM_HOME" \
-  && bundle config --global bin "$GEM_HOME/bin"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+FROM quay.io/actcat/devon_rex_base:1.0.2


### PR DESCRIPTION
This Dockerfile contains `FROM` instruction only. Because the base image has `bundle install`.


